### PR TITLE
Remove an unnecessary new line

### DIFF
--- a/source/basics.rst
+++ b/source/basics.rst
@@ -3,8 +3,7 @@ Basics
 
 WebExtensions Experiments provide a way for developers to tinker with new APIs for WebExtensions. They allow new WebExtensions APIs to be implemented in an extension. They can be used to prototype APIs for landing in Firefox, or for use on `Nightly <https://nightly.mozilla.org/>`_ or `Developer Edition <https://developer.mozilla.org/en-US/Firefox/Developer_Edition>`_.
 
-.. note:: If you simply want to request a WebExtensions API, please see
-`this page on the Firefox wiki <https://wiki.mozilla.org/WebExtensions/NewAPIs>`_.
+.. note:: If you simply want to request a WebExtensions API, please see `this page on the Firefox wiki <https://wiki.mozilla.org/WebExtensions/NewAPIs>`_.
 
 .. note:: If you'd like to land a WebExtensions API straight into Firefox, are familiar with building `mozilla-central <https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Introduction>`_, working with `Bugzilla <https://bugzilla.mozilla.org/>`_, the `try server <https://treeherder.mozilla.org/#/jobs?repo=try>`_, then please `file a bug <https://bugzilla.mozilla.org/enter_bug.cgi?product=WebExtensions&component=Untriaged>`_ and follow the usual Firefox development process.
 


### PR DESCRIPTION
I think "this page on the Firefox Wiki" should be in Note block then I think we should remove a new line 
following "please see" in source/basics.rst.

![image](https://user-images.githubusercontent.com/7637832/73881513-52452e00-4815-11ea-9167-3824e3963d21.png)
